### PR TITLE
Error-handling and reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>check-staging-properties-maven-plugin</artifactId>
     <name>check-staging-properties-maven-plugin</name>
     <packaging>maven-plugin</packaging>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <description>Checks stage dependent properties</description>
     <url>https://github.com/codecentric/check-staging-properties-maven-plugin</url>
     <organization>

--- a/src/main/java/de/codecentric/CheckStagingPropertiesMojo.java
+++ b/src/main/java/de/codecentric/CheckStagingPropertiesMojo.java
@@ -49,10 +49,10 @@ class CheckStagingPropertiesMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (groups != null && groups.size() > 0) {
             for (String group : groups) {
-                doChecks(getProperties(group));
+                doChecks(group, getProperties(group));
             }
         } else {
-            doChecks(getProperties(null));
+            doChecks("", getProperties());
         }
     }
 
@@ -100,18 +100,18 @@ class CheckStagingPropertiesMojo extends AbstractMojo {
         }
     }
 
-    private void doChecks(ArrayList<Properties> props) throws MojoExecutionException, MojoFailureException {
+    private void doChecks(String group, ArrayList<Properties> props) throws MojoExecutionException, MojoFailureException {
         if (props.size() > 1) {
             if (!StagingProperties.sizesEqual(props)) {
-                this.error("Sizes (number of keys) do not equal");
+                this.error("In group '" + group + "': Sizes (number of keys) are not equal");
             }
 
             if (!StagingProperties.keysEqual(props)) {
-                this.error("Keys do not equal");
+                this.error("In group '" + group + "': Keys are not equal");
             }
 
             if (!StagingProperties.valuesPresent(props)) {
-                this.error("Some values are empty");
+                this.error("In group '" + group + "': Some values are empty");
             }
         }
     }

--- a/src/main/java/de/codecentric/Files.java
+++ b/src/main/java/de/codecentric/Files.java
@@ -35,7 +35,7 @@ final class Files {
     }
 
     static boolean matchesGroup(File f, String groupPattern) {
-        return groupPattern == null || !f.getName().matches(groupPattern);
+        return groupPattern == null || f.getName().matches(groupPattern);
     }
 
 }

--- a/src/test/java/de/codecentric/CheckStagingPropertiesMojoTest.java
+++ b/src/test/java/de/codecentric/CheckStagingPropertiesMojoTest.java
@@ -43,24 +43,24 @@ public class CheckStagingPropertiesMojoTest {
     public final ExpectedException exception = ExpectedException.none();
 
     @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    public final TemporaryFolder folder = new TemporaryFolder();
 
     @Test
-    public void shouldContainEmptyList() {
+    public void shouldContainEmptyList() throws MojoExecutionException {
         TestCheckStagingPropertiesMojo mojo = new TestCheckStagingPropertiesMojo();
         ArrayList<Properties> properties = mojo.getProperties();
         assertEquals(0, properties.size());
     }
 
     @Test
-    public void shouldNotUseNonPropertiesFiles() throws IOException {
+    public void shouldNotUseNonPropertiesFiles() throws IOException, MojoExecutionException {
         TestCheckStagingPropertiesMojo mojo = new TestCheckStagingPropertiesMojo();
 
         folder.newFolder("child");
         folder.newFile("app-DEV.properties");
         folder.newFile("app-PRD.properties");
         folder.newFile(".DS_Store");
-        folder.newFolder("test.pdf");
+        folder.newFile("test.pdf");
 
         assertEquals(2, mojo.getProperties().size());
     }
@@ -78,7 +78,7 @@ public class CheckStagingPropertiesMojoTest {
     }
 
     @Test
-    public void shouldContainEmptyPropertiesListWhenInputFileDoesNotExist() {
+    public void shouldContainEmptyPropertiesListWhenInputFileDoesNotExist() throws MojoExecutionException {
         TestCheckStagingPropertiesMojo mojo = new TestCheckStagingPropertiesMojo(new File("/does/not/exist"), true, null);
         assertEquals(0, mojo.getProperties().size());
     }
@@ -166,6 +166,18 @@ public class CheckStagingPropertiesMojoTest {
         groups.add("bla-.*");
 
         TestCheckStagingPropertiesMojo mojo = new TestCheckStagingPropertiesMojo(folder.getRoot(), false, groups);
+        mojo.execute();
+    }
+
+    @Test
+    public void unreadableFile() throws Exception {
+        this.createTestPropertiesFile("test-DEV.properties", "test.one=one\ntest.two=two");
+        File f = new File(folder.getRoot().toString() + "/" + "test-DEV.properties");
+        f.setReadable(false);
+        ArrayList<String> groups = new ArrayList<String>();
+        groups.add("test-.*");
+        TestCheckStagingPropertiesMojo mojo = new TestCheckStagingPropertiesMojo(folder.getRoot(), false, groups);
+        exception.expect(MojoExecutionException.class);
         mojo.execute();
     }
 

--- a/src/test/java/de/codecentric/TestFiles.java
+++ b/src/test/java/de/codecentric/TestFiles.java
@@ -82,4 +82,18 @@ public class TestFiles {
         assertFalse(isPropertiesFileHelper(".DS_Store"));
     }
 
+    @Test
+    public void matchesGroupShouldMatchWithoutPattern() {
+        assertTrue(Files.matchesGroup(null, null));
+    }
+
+    @Test
+    public void matchesGroupShouldMatch() {
+        assertTrue(Files.matchesGroup(new File("abc.properties"), "ab.\\.properties"));
+    }
+
+    @Test
+    public void matchesGroupShouldNotMatch() {
+        assertFalse(Files.matchesGroup(new File("abc.properties"), "de.\\.properties"));
+    }
 }


### PR DESCRIPTION
Unreadable files lead to Build-Breaker (via MojoExecutionException). 
On error the actual group is printed in addition the the error type.