### PR TITLE
Add yaml support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,10 @@ buildNumber.properties
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /s101plugin.state
+
+
+### Eclipse ###
+.settings/
+.classpath
+.project
+bin/

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <maven.plugin.api.version>3.3.9</maven.plugin.api.version>
         <maven.plugin.annotations.version>3.5</maven.plugin.annotations.version>
         <junit.version>4.13.1</junit.version>
+        <snakeyaml.version>2.3</snakeyaml.version>
     </properties>
 
     <scm>
@@ -190,6 +191,11 @@
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/de/codecentric/CheckStagingPropertiesMojo.java
+++ b/src/main/java/de/codecentric/CheckStagingPropertiesMojo.java
@@ -28,7 +28,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.*;
 

--- a/src/main/java/de/codecentric/CheckStagingPropertiesMojo.java
+++ b/src/main/java/de/codecentric/CheckStagingPropertiesMojo.java
@@ -55,6 +55,7 @@ class CheckStagingPropertiesMojo extends AbstractMojo {
 
     private ArrayList<Properties> getPropertiesRecursively(File directory, String pattern)
             throws MojoExecutionException {
+        fileNames = new LinkedList<>();
         ArrayList<Properties> propertyFiles = new ArrayList<>(20);
         if (directory == null || !directory.exists()) {
             getLog().warn("Directory `" +

--- a/src/main/java/de/codecentric/CheckStagingPropertiesMojo.java
+++ b/src/main/java/de/codecentric/CheckStagingPropertiesMojo.java
@@ -149,9 +149,9 @@ class CheckStagingPropertiesMojo extends AbstractMojo {
                     errors.add("file: " + props.get(i).getFileName() + ", keys: \n" + missingValues);
                 }
                 if (DEFAULT_GROUP.equals(group)) {
-                    throw new MojoFailureException("There are some empty values in: " + errors + "`");
+                    throw new MojoFailureException("There are some empty values in:\n`" + errors + "`");
                 } else {
-                    throw new MojoFailureException("There are some empty values in group `" + group + "` and `" + errors + "`");
+                    throw new MojoFailureException("There are some empty values in group `" + group + "` and\n`" + errors + "`");
                 }
             }
         }

--- a/src/main/java/de/codecentric/FileProperties.java
+++ b/src/main/java/de/codecentric/FileProperties.java
@@ -29,6 +29,8 @@ import java.util.Properties;
 
 public class FileProperties extends Properties {
 
+    private static final long serialVersionUID = -2541985862257082751L;
+
     private File file;
 
     public FileProperties(File file) {

--- a/src/main/java/de/codecentric/FileProperties.java
+++ b/src/main/java/de/codecentric/FileProperties.java
@@ -1,0 +1,45 @@
+package de.codecentric;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+/*
+ * #%L
+ * check-staging-properties-maven-plugin
+ * %%
+ * Copyright (C) 2016 codecentric AG
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Properties;
+
+public class FileProperties extends Properties {
+
+    private File file;
+
+    public FileProperties(File file) {
+        this.file = file;
+    }
+
+    public void load() throws FileNotFoundException, IOException {
+        super.load(new FileInputStream(file.getAbsolutePath()));
+    }
+
+    public String getFileName () {
+        return file.getName();
+    }
+}

--- a/src/main/java/de/codecentric/Files.java
+++ b/src/main/java/de/codecentric/Files.java
@@ -24,6 +24,10 @@ import java.io.File;
 
 final class Files {
 
+    public static final String PROPERTIES = "properties";
+    public static final String YAML = "yaml";
+    public static final String YML = "yml";
+    
     static String getExtension(File f) {
         int i = f.getName().lastIndexOf('.');
         return (i > 0 ? f.getName().substring(i + 1) : null);
@@ -31,7 +35,12 @@ final class Files {
 
     static boolean isPropertiesFile(File f) {
         String extension = getExtension(f);
-        return extension != null && extension.equals("properties");
+        return extension != null && extension.equals(PROPERTIES);
+    }
+
+    static boolean isYamlFile(File f) {
+        String extension = getExtension(f);
+        return extension != null && (extension.equals(YAML) || extension.equals(YML));
     }
 
     static boolean matchesGroup(File f, String groupPattern) {

--- a/src/main/java/de/codecentric/StagingProperties.java
+++ b/src/main/java/de/codecentric/StagingProperties.java
@@ -24,7 +24,7 @@ import java.util.*;
 
 final class StagingProperties {
 
-    static boolean sizesEqual(Collection<Properties> props) {
+    static boolean sizesEqual(Collection<? extends Properties> props) {
         HashSet<Integer> sizes = new HashSet<Integer>(props.size());
         for (Properties prop : props) {
             sizes.add(prop.size());
@@ -32,7 +32,7 @@ final class StagingProperties {
         return sizes.size() == 1;
     }
 
-    static boolean valuesPresent(Collection<Properties> props) {
+    static boolean valuesPresent(Collection<? extends Properties> props) {
         for (Properties prop : props) {
             for (Object value : prop.values()) {
                 if (((String) value).length() == 0) {
@@ -43,7 +43,7 @@ final class StagingProperties {
         return true;
     }
 
-    static boolean keysEqual(Collection<Properties> props) {
+    static boolean keysEqual(Collection<? extends Properties> props) {
         ArrayList<Set<Object>> keysList = new ArrayList<Set<Object>>(props.size());
         for (Properties prop : props) {
             keysList.add(prop.keySet());

--- a/src/main/java/de/codecentric/YamlLoader.java
+++ b/src/main/java/de/codecentric/YamlLoader.java
@@ -1,0 +1,112 @@
+package de.codecentric;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+
+/*
+ * #%L
+ * check-staging-properties-maven-plugin
+ * %%
+ * Copyright (C) 2016 codecentric AG
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.yaml.snakeyaml.Yaml;
+
+/*
+ * #%L
+ * check-staging-properties-maven-plugin
+ * %%
+ * Copyright (C) 2016 codecentric AG
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class YamlLoader {
+
+    private File file;
+
+    public YamlLoader(File file) {
+        this.file = file;
+    }
+
+    public FileProperties load() throws FileNotFoundException {
+        FileProperties props = new FileProperties(file);
+        Yaml yaml = new Yaml();
+        Object yamlObj = yaml.load(new FileInputStream(file.getAbsolutePath()));
+        appendMap(props, (HashMap) yamlObj, null);
+        return props;
+    }
+
+    private void appendMap(FileProperties props, HashMap map, String parentKey) {
+        if (map.isEmpty()) {
+            return;
+        }
+        Iterator iterator = map.keySet().iterator();
+        while (iterator.hasNext()) {
+            String key = (String) iterator.next();
+            Object value = map.get(key);
+            if (value instanceof HashMap) {
+                appendMap(props, (HashMap) value, (String) key);
+            } else {
+                key = produceKey(parentKey, key);
+                appendProperty(props, key, value);
+            }
+        }
+    }
+
+    private void appendProperty(FileProperties props, String key, Object value) {
+        if (value == null) {
+            value = "";
+        }
+        if (value instanceof Integer) {
+            props.put(key, ((Integer) value).toString());
+        } else if (value instanceof Boolean) {
+            props.put(key, ((Boolean) value).toString());
+        } else if (value instanceof Double) {
+            props.put(key, ((Double) value).toString());
+        } else if (value instanceof ArrayList) {
+            ArrayList list = (ArrayList) value;
+            for (int i = 0; i < list.size(); i++) {
+                appendProperty(props, produceKey(key, Integer.toString(i)), list.get(i));
+            }
+        } else {
+            props.put(key, value);
+        }
+    }
+
+    private String produceKey(String parentKey, String key) {
+        if (parentKey != null) {
+            key = parentKey + "." + key;
+        }
+        return key;
+    }
+}

--- a/src/main/java/de/codecentric/YamlLoader.java
+++ b/src/main/java/de/codecentric/YamlLoader.java
@@ -3,7 +3,6 @@ package de.codecentric;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/src/test/java/de/codecentric/AbstractMojoTest.java
+++ b/src/test/java/de/codecentric/AbstractMojoTest.java
@@ -1,0 +1,55 @@
+package de.codecentric;
+
+/*
+ * #%L
+ * check-staging-properties-maven-plugin
+ * %%
+ * Copyright (C) 2016 codecentric AG
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+public abstract class AbstractMojoTest {
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    protected File createTestPropertiesFile(String filename, String content) throws Exception {
+        File f = new File(folder.getRoot().toString() + "/" + filename);
+        BufferedWriter w = new BufferedWriter(new FileWriter(f));
+        w.write(content);
+        w.close();
+        return f;
+    }
+
+    protected class TestCheckStagingPropertiesMojo extends CheckStagingPropertiesMojo {
+        TestCheckStagingPropertiesMojo() {
+            this.directory = folder.getRoot();
+            this.groups = null;
+        }
+
+        TestCheckStagingPropertiesMojo(File directory, List<String> groups) {
+            this.directory = directory;
+            this.groups = groups;
+        }
+    }
+}

--- a/src/test/java/de/codecentric/CheckStagingPropertiesMojoTest.java
+++ b/src/test/java/de/codecentric/CheckStagingPropertiesMojoTest.java
@@ -148,6 +148,10 @@ public class CheckStagingPropertiesMojoTest {
 
     @Test
     public void unreadableFile() throws Exception {
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName != null && osName.startsWith("windows")) {
+            return;
+        }
         File f = createTestPropertiesFile("test-DEV.properties", "test.one=one\ntest.two=two");
         boolean successful = f.setReadable(false);
         assertTrue(successful);

--- a/src/test/java/de/codecentric/CheckStagingPropertiesMojoTest.java
+++ b/src/test/java/de/codecentric/CheckStagingPropertiesMojoTest.java
@@ -118,10 +118,16 @@ public class CheckStagingPropertiesMojoTest {
     public void shouldBreakBuildWhenPropertiesValuesAreNotEqual() throws Exception {
         createTestPropertiesFile("app-DEV.properties", "test.one = one\ntest.two =");
         createTestPropertiesFile("app-PRD.properties", "test.one =\ntest.two =");
+        createTestPropertiesFile("bla-DEV.properties", "bla.bla=bla");
+        createTestPropertiesFile("bla-PRD.properties", "bla.bla=bla");
 
-        TestCheckStagingPropertiesMojo mojo = new TestCheckStagingPropertiesMojo();
+        ArrayList<String> groups = new ArrayList<>();
+        groups.add("bla-.*"); // Files with less properties must be first.
+        groups.add("app-.*");
+        TestCheckStagingPropertiesMojo mojo = new TestCheckStagingPropertiesMojo(folder.getRoot(), groups);
+
         exception.expect(MojoFailureException.class);
-        final String exceptionMessage = "There are some empty values in: [file: app-DEV.properties, keys: \n" +
+        final String exceptionMessage = "There are some empty values in group `app-.*` and `[file: app-DEV.properties, keys: \n" +
                 "test.two\n" +
                 ", file: app-PRD.properties, keys: \n" +
                 "test.two\n" +

--- a/src/test/java/de/codecentric/CheckStagingPropertiesMojoTest.java
+++ b/src/test/java/de/codecentric/CheckStagingPropertiesMojoTest.java
@@ -114,7 +114,7 @@ public class CheckStagingPropertiesMojoTest extends AbstractMojoTest {
 
         TestCheckStagingPropertiesMojo mojo = new TestCheckStagingPropertiesMojo();
         exception.expect(MojoFailureException.class);
-        final String exceptionMessage = "There are some empty values in: [file: app-DEV.properties, keys: \n" +
+        final String exceptionMessage = "There are some empty values in:\n`[file: app-DEV.properties, keys: \n" +
                 "test.two\n" +
                 ", file: app-PRD.properties, keys: \n" +
                 "test.two\n" +
@@ -137,7 +137,7 @@ public class CheckStagingPropertiesMojoTest extends AbstractMojoTest {
         TestCheckStagingPropertiesMojo mojo = new TestCheckStagingPropertiesMojo(folder.getRoot(), groups);
 
         exception.expect(MojoFailureException.class);
-        final String exceptionMessage = "There are some empty values in group `app-.*` and `[file: app-DEV.properties, keys: \n" +
+        final String exceptionMessage = "There are some empty values in group `app-.*` and\n`[file: app-DEV.properties, keys: \n" +
                 "test.two\n" +
                 ", file: app-PRD.properties, keys: \n" +
                 "test.two\n" +

--- a/src/test/java/de/codecentric/TestYamlLoader.java
+++ b/src/test/java/de/codecentric/TestYamlLoader.java
@@ -1,0 +1,67 @@
+package de.codecentric;
+
+import static org.junit.Assert.assertEquals;
+
+/*
+ * #%L
+ * check-staging-properties-maven-plugin
+ * %%
+ * Copyright (C) 2016 codecentric AG
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Properties;
+
+import org.junit.Test;
+
+public class TestYamlLoader extends AbstractMojoTest {
+
+    @Test
+    public void testSimpleDataTypes() throws Exception {
+        File file = createTestPropertiesFile("test-DEV.yaml", "test:\n  string: \"one\"\n  hex: 0x12d4\n  octal: 012345\n  exp: 12.3015e+05\n  boolean: true\n  integer: 20\n");
+        
+        Properties props = new YamlLoader(file).load();
+        
+        assertEquals("one", props.get("test.string"));
+        assertEquals("4820", props.get("test.hex"));
+        assertEquals("5349", props.get("test.octal"));
+        assertEquals("1230150.0", props.get("test.exp"));
+        assertEquals("true", props.get("test.boolean"));
+        assertEquals("20", props.get("test.integer"));
+    }
+
+    @Test
+    public void testListDataTypes() throws Exception {
+        File file = createTestPropertiesFile("test-DEV.yaml", "test:\n  items:\n    - 6\n    - 7\n    - 8\n");
+        
+        Properties props = new YamlLoader(file).load();
+        
+        assertEquals("6", props.get("test.items.0"));
+        assertEquals("7", props.get("test.items.1"));
+        assertEquals("8", props.get("test.items.2"));
+    }
+
+    @Test
+    public void testEmptyProperty() throws Exception {
+        
+        File file = createTestPropertiesFile("test-DEV.yaml", "test:\n  items:\n    - 6\n    - 7\n    - 8\n  emptyProp:\n");
+        
+        Properties props = new YamlLoader(file).load();
+        
+        assertEquals("", props.get("test.emptyProp"));
+    }
+}

--- a/src/test/java/de/codecentric/TestYamlLoader.java
+++ b/src/test/java/de/codecentric/TestYamlLoader.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertEquals;
  */
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.util.Properties;
 
 import org.junit.Test;


### PR DESCRIPTION
### Reason for the pull request

We want to validate deployment descriptor files during the build process of Anypoint APIs.

**Example deployment descriptor**

```yaml
deployment:
  applicationName: my-fancy-api
  businessGroup: name-of-the-business-group
  muleVersion: 4.6.7
  javaVersion: 17
  replicas: 1
  vCores: 0.1
  target: devtest
  provider: MC
  timeout: 600000
```

### Changes of the pull request

- fixes a bug that is demonstrated with commit [789c5ca](https://github.com/tools400/check-staging-properties-maven-plugin/commit/789c5ca370e48caaa457fa80ad597d6939741aae)
- add yaml support to the plug-in

### Reproducing the bug

**Preconditions**
- current plugin version 1.0.5-SNAPSHOT before this pull request
- pom defines "groups"
- the files with less properties must be associated to the first group (group "bla-.*")

**Reason of the bug**

Variable `fileNames` was not cleared when processing the next group.

### Open issue

- Although command `mvn test` runs fine on my computer, the GitLab build pipeline fails with the following error message:
```text
[ERROR] Failed to execute goal de.codecentric:check-staging-properties-maven-plugin:1.0.5-SNAPSHOT:check (default) on project showcase-mule4-sapi-app: Execution default of goal de.codecentric:check-staging-properties-maven-plugin:1.0.5-SNAPSHOT:check failed: A required class was missing while executing de.codecentric:check-staging-properties-maven-plugin:1.0.5-SNAPSHOT:check: org/yaml/snakeyaml/Yaml
```
- I am not a Maven expert and I could not yet figure out how to solve it.
